### PR TITLE
[fix] login and base url

### DIFF
--- a/epfl-coming-soon.php
+++ b/epfl-coming-soon.php
@@ -4,14 +4,14 @@ Plugin Name: EPFL Coming Soon
 Plugin URI: https://github.com/epfl-si/wp-plugin-epfl-coming-soon
 Description: EPFL coming soon / maintenance plugin
 Author: EPFL SI
-Version: 0.0.4
+Version: 0.0.5
 Author URI: https://github.com/epfl-si
 */
 
 defined('ABSPATH')
     or die('Direct access not allowed.');
 
-define("EPFL_COMING_SOON_VERSION", "0.0.4");
+define("EPFL_COMING_SOON_VERSION", "0.0.5");
 
 require_once WP_CONTENT_DIR . '/plugins/epfl-coming-soon/src/classes/epfl-coming-soon.php';
 

--- a/src/classes/epfl-coming-soon.php
+++ b/src/classes/epfl-coming-soon.php
@@ -113,13 +113,21 @@ class EPFLComingSoon {
             // Whenever the user create the page in the plugin's TinyMCE editor
             } elseif (trim(get_option('epfl_csp_options')['page_content']) !== '') {
                 $template_path = __DIR__ . '/../templates/page-template.html';
-                
                 $epfl_coming_soon_template = file_get_contents($template_path);
-                //die($epfl_coming_soon_template);
+
+                // Define the HTML <base> element in the template
+                // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+                $epfl_coming_soon_template = str_replace("{{ BASE_URL }}", home_url(''), $epfl_coming_soon_template);
+
+                // Define the page title in the template
                 $epfl_coming_soon_template = str_replace("{{ TITLE }}", get_bloginfo('name') . ' &raquo; ' . get_option('epfl_csp_options')['page_title'], $epfl_coming_soon_template);
 
+                // Define the CONTENT in the template
                 $epfl_coming_soon_template = str_replace("{{ CONTENT }}", get_option('epfl_csp_options')['page_content'], $epfl_coming_soon_template);
+
+                // Display the template
                 echo $epfl_coming_soon_template;
+
                 exit();
 
             // In every other cases, just display a plain text sorry message

--- a/src/classes/epfl-coming-soon.php
+++ b/src/classes/epfl-coming-soon.php
@@ -75,8 +75,12 @@ class EPFLComingSoon {
     }
 
     public function epfl_maintenance_load()
-    {   
-        
+    {
+        // Leave wp-admin / wp-login apart from epfl-coming-soon plugin
+        if (preg_match("/login|admin|dashboard|account/i", $_SERVER['REQUEST_URI']) > 0) {
+            return;
+        }
+
         if (php_sapi_name() !== 'cli'                      // not on cli (e.g. wp-cli)
             && ! is_user_logged_in()                       // not when the user is authenticaed
             && ! is_admin()                                // not on back office

--- a/src/templates/page-template.html
+++ b/src/templates/page-template.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
+    <base href="{{ BASE_URL }}">
     <link rel="stylesheet" href="https://web2018.epfl.ch/5.0.2/css/elements.min.css">
     <title>{{ TITLE }}</title>
   </head>


### PR DESCRIPTION
This PR fixes 
  1. The wp-login.php or wp-admin or admin login page (should also work with customized login page) : before the fix, users weren't able to login when the epfl-coming-soon was active.
  2. The template now uses the HTML <base> element (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) and relative links will always work.

Fixes #9 (29759e3)