### PR TITLE
Fix registering rest route with an ending trail

### DIFF
--- a/src/classes/class-epflcomingsoon.php
+++ b/src/classes/class-epflcomingsoon.php
@@ -39,7 +39,7 @@ class EPFLComingSoon {
 	 **/
 	public function epfl_coming_soon_rest_api() {
 		register_rest_route(
-			'epfl/v1/',
+			'epfl/v1',
 			'coming-soon',
 			array(
 				'methods'             => WP_REST_Server::READABLE,


### PR DESCRIPTION
Because sad WP otherwise, giving this notice:
 https://github.com/WordPress/WordPress/blob/db5d8b5e038e668be63b1d37ae6551c4fa06d6e9/wp-includes/rest-api.php#L51