### PR TITLE
Add endpoint in WordPress REST API

### DIFF
--- a/epfl-coming-soon.php
+++ b/epfl-coming-soon.php
@@ -46,7 +46,7 @@ add_action( 'init', 'epfl_coming_soon_plugin_textdomain' );
 add_action( 'rest_api_init', function() {
     register_rest_route( 'epfl-coming-soon/v1', 'status', array(
         'method'   => 'WP_REST_Server::READABLE',
-        'callback' => __NAMESPACE__ . '\\get_epfl_coming_soon_status',
+        'callback' => 'get_epfl_coming_soon_status',
     ) );
 } );
 

--- a/epfl-coming-soon.php
+++ b/epfl-coming-soon.php
@@ -39,3 +39,18 @@ function epfl_coming_soon_plugin_textdomain() {
 	load_plugin_textdomain( 'epfl-coming-soon', false, 'epfl-coming-soon/src/languages/' );
 }
 add_action( 'init', 'epfl_coming_soon_plugin_textdomain' );
+
+/**
+ * Add endpoint to WordPress REST API -> /wp-json/epfl-coming-soon/v1/status
+ */
+add_action( 'rest_api_init', function() {
+    register_rest_route( 'epfl-coming-soon/v1', 'status', array(
+        'method'   => 'WP_REST_Server::READABLE',
+        'callback' => __NAMESPACE__ . '\\get_epfl_coming_soon_status',
+    ) );
+} );
+
+function get_epfl_coming_soon_status() {
+    $status = get_option('epfl_csp_options')['status'] ? '1' : '0';
+    return $status;
+} 


### PR DESCRIPTION
**Description**

We need this plugin status for the 'Search-inside' project.

**To test**

1. Activate/deactivate this plugin→ $MY_SITE/wp-admin/options-general.php?page=epfl-coming-soon
1. Then go to → $MY_SITE/wp-json/epfl-coming-soon/v1/status