### PR TITLE
Remove duplicated endpoint

### DIFF
--- a/epfl-coming-soon.php
+++ b/epfl-coming-soon.php
@@ -39,19 +39,3 @@ function epfl_coming_soon_plugin_textdomain() {
 	load_plugin_textdomain( 'epfl-coming-soon', false, 'epfl-coming-soon/src/languages/' );
 }
 add_action( 'init', 'epfl_coming_soon_plugin_textdomain' );
-
-/**
- * Add endpoint to WordPress REST API -> /wp-json/epfl-coming-soon/v1/status
- */
-add_action( 'rest_api_init', function() {
-    register_rest_route( 'epfl-coming-soon/v1', 'status', array(
-        'method'   => 'WP_REST_Server::READABLE',
-        'callback' => 'get_epfl_coming_soon_status',
-        'permission_callback' => '__return_true',
-    ) );
-} );
-
-function get_epfl_coming_soon_status() {
-    $status = get_option('epfl_csp_options')['status'] ? '1' : '0';
-    return $status;
-} 


### PR DESCRIPTION
**Description**

As an endpoint was already existing (/wp-json/epfl/v1/coming-soon), with `status` value (plugin activated or not):
https://github.com/epfl-si/wp-plugin-epfl-coming-soon/blob/618dfd2b01eaf4a9349506b7c19f62e8cfbbbcf9/src/classes/class-epflcomingsoon.php#L65

We can drop the duplicated created in https://github.com/epfl-si/wp-plugin-epfl-coming-soon/pull/23/files (didn't see when I made it).